### PR TITLE
Async at scrolling

### DIFF
--- a/src/org/ligi/fast/AppInfoAdapter.java
+++ b/src/org/ligi/fast/AppInfoAdapter.java
@@ -31,10 +31,13 @@ public class AppInfoAdapter extends BaseAdapter {
     private List<AppInfo> pkgAppsListAll;
     private String act_query = "";
     private String colorString = "";
+    
+    private boolean isScrolling = false;
 
     public AppInfoAdapter(Context _ctx, List<AppInfo> _pkgAppsListAll) {
         ctx = _ctx;
         setAllAppsList(_pkgAppsListAll);
+        
     }
 
     public void setAllAppsList(List<AppInfo> _pkgAppsListAll) {
@@ -95,7 +98,7 @@ public class AppInfoAdapter extends BaseAdapter {
         if (imageView != null) {
         	if (position == 1)
     			firstTimeLoading += 1;
-        	if (firstTimeLoading < 3) {
+        	if ( !isScrolling || firstTimeLoading < 3) {
         		
         		Drawable drawable = pkgAppsListShowing.get(position).getIcon();
         		holder.image.setImageDrawable(drawable);
@@ -188,6 +191,10 @@ public class AppInfoAdapter extends BaseAdapter {
 
     public FASTPrefs getPrefs() {
         return ((ApplicationContext) ctx.getApplicationContext()).getPrefs();
+    }
+    
+    public void setScrolling(boolean _scrolling) {
+    	isScrolling = _scrolling;
     }
 
 }

--- a/src/org/ligi/fast/SearchActivity.java
+++ b/src/org/ligi/fast/SearchActivity.java
@@ -14,6 +14,8 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.AbsListView;
+import android.widget.AbsListView.OnScrollListener;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.AdapterView.OnItemLongClickListener;
@@ -81,6 +83,7 @@ public class SearchActivity extends SherlockActivity {
 		mAdapter = new AppInfoAdapter(this, pkgAppsListTemp);		
 		// sync was here
 		
+		
 		if (pkgAppsListTemp.size() == 0)
 			new BaseAppGatherAsyncTask(this) {
 	
@@ -137,6 +140,21 @@ public class SearchActivity extends SherlockActivity {
 		mGridView = (GridView) findViewById(R.id.listView);
 
 		disableOverScoll(mGridView);
+		mGridView.setOnScrollListener(new OnScrollListener(){
+			public void onScrollStateChanged(AbsListView view, int scrollState) {
+				if(scrollState == OnScrollListener.SCROLL_STATE_IDLE) { // Scrolling stopped
+					mAdapter.setScrolling(false);
+				} else {
+					mAdapter.setScrolling(true);
+				}
+			}
+
+			public void onScroll(AbsListView view, int firstVisibleItem,
+					int visibleItemCount, int totalItemCount) {
+				// TODO Auto-generated method stub
+
+			}
+		});
 
 
         //mGridView.setAdapter(mAdapter);


### PR DESCRIPTION
Only use extra threads when scrolling. This will reduce power consumption and fix some graphical glitches when searching.

Also see Issue #7
