### PR TITLE
No fullscreen keyboard in landscape mode.

### DIFF
--- a/src/org/ligi/fast/SearchActivity.java
+++ b/src/org/ligi/fast/SearchActivity.java
@@ -150,7 +150,7 @@ public class SearchActivity extends SherlockActivity {
 		
 		search_et.setLayoutParams(lparams);
 		search_et.setSingleLine();
-		search_et.setImeOptions(EditorInfo.IME_ACTION_DONE);
+		search_et.setImeOptions(EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_EXTRACT_UI);
 		search_et.setImeActionLabel("Launch", EditorInfo.IME_ACTION_DONE);
 		
 		search_et.setOnEditorActionListener(new OnEditorActionListener() {


### PR DESCRIPTION
Just a very minor detail.
The keyboard covered the whole screen in landscape mode. So no results were showed. I disabled the "extra ui" to avoid this.

Old vs. new:
![landscape_old](https://f.cloud.github.com/assets/566972/74448/d6d78f64-6091-11e2-8f5f-78c4c604a948.png)

![landscape_new](https://f.cloud.github.com/assets/566972/74449/dc47ae98-6091-11e2-849b-a0ccd46a93fa.png)
