### PR TITLE
Use proper layout for help dialog

### DIFF
--- a/android/src/main/res/layout/help_dialog.xml
+++ b/android/src/main/res/layout/help_dialog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/help_text"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    tools:text="@string/help_content" />

--- a/android/src/withExtras/java/org/ligi/fast/ui/HelpDialog.java
+++ b/android/src/withExtras/java/org/ligi/fast/ui/HelpDialog.java
@@ -1,11 +1,14 @@
 package org.ligi.fast.ui;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
+import android.view.LayoutInflater;
+import android.view.View;
 import android.widget.TextView;
 
 import org.ligi.fast.R;
@@ -13,14 +16,13 @@ import org.ligi.fast.R;
 class HelpDialog {
 
     public static void show(Context ctx) {
-
-        TextView tv = new TextView(ctx);
-        tv.setPadding(10, 10, 10, 10);
+        @SuppressLint("InflateParams") View view = LayoutInflater.from(ctx).inflate(R.layout.help_dialog, null);
+        TextView tv = (TextView) view.findViewById(R.id.help_text);
         tv.setText(Html.fromHtml(ctx.getString(R.string.help_content)));
-
         Linkify.addLinks(tv, Linkify.ALL);
         tv.setMovementMethod(LinkMovementMethod.getInstance());
-        new AlertDialog.Builder(ctx).setTitle(R.string.help_label).setView(tv)
+
+        new AlertDialog.Builder(ctx).setTitle(R.string.help_label).setView(view)
                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
This way we can easily add padding in DIPs.

Before:
![fast_help_before](https://cloud.githubusercontent.com/assets/218061/5641460/83af4090-9639-11e4-8f5b-f40530bc6e12.png)

After:
![fast_help_after](https://cloud.githubusercontent.com/assets/218061/5641461/83b5d1f8-9639-11e4-8dfd-1ed4347114dc.png)
