### PR TITLE
Allow FAST(ER) to be set as default search assistant

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -51,6 +51,8 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
+                <action android:name="android.intent.action.SEARCH_LONG_PRESS" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
The manifest.xml file was missing the lines I added, which also consider SEARCH_LONG_PRESS
and the category DEFAULT for these actions.