### PR TITLE
Implement "Sort by last used"

### DIFF
--- a/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
+++ b/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
@@ -50,6 +50,7 @@ public class BaseAppGatherAsyncTask extends AsyncTask<Void, AppInfo, Void> {
                         for(AppInfo oldInfo : appInfoList) {
                             if (oldInfo.getActivityName().equals(actAppInfo.getActivityName())) {
                                 actAppInfo.setCallCount(oldInfo.getCallCount());
+                                actAppInfo.setLastUsedTime(oldInfo.getLastUsedTime());
                                 break;
                             }
                         }

--- a/android/src/main/java/org/ligi/fast/model/AppInfo.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfo.java
@@ -25,6 +25,7 @@ public class AppInfo {
     private String activityName;
     private String hash;
     private int callCount;
+    private long lastUsedTime;
     private boolean isValid = true;
 
     private final AppIconCache iconCache;
@@ -38,7 +39,7 @@ public class AppInfo {
 
         String[] app_info_str_split = cache_str.split(SEPARATOR);
 
-        if (app_info_str_split.length < 5) {
+        if (app_info_str_split.length < 6) {
             isValid = false;
             return;
         }
@@ -48,6 +49,7 @@ public class AppInfo {
         packageName = app_info_str_split[2];
         activityName = app_info_str_split[3];
         callCount = Integer.parseInt(app_info_str_split[4]);
+        lastUsedTime = Long.parseLong(app_info_str_split[5]);
 
         calculateAlternateLabelAndPackageName();
 
@@ -67,6 +69,7 @@ public class AppInfo {
             activityName = "unknown";
         }
         callCount = 0;
+        lastUsedTime = 0;
 
         hash = calculateTheHash();
         calculateAlternateLabelAndPackageName();
@@ -80,7 +83,7 @@ public class AppInfo {
 
     public String toCacheString() {
         return hash + SEPARATOR + label + SEPARATOR + packageName +
-                SEPARATOR + activityName + SEPARATOR + callCount;
+                SEPARATOR + activityName + SEPARATOR + callCount + SEPARATOR + lastUsedTime;
     }
 
     private String calculateTheHash() {
@@ -147,6 +150,18 @@ public class AppInfo {
         callCount++;
     }
 
+    public long getLastUsedTime() {
+        return lastUsedTime;
+    }
+
+    public void setLastUsedTime(long usedTime) {
+        lastUsedTime = usedTime;
+    }
+
+    public void updateLastUsedTime() {
+        lastUsedTime = System.currentTimeMillis();
+    }
+
     public boolean isValid() {
         return isValid;
     }
@@ -167,6 +182,10 @@ public class AppInfo {
         final int localCallCount = getCallCount();
         final int remoteCallCount = appInfo.getCallCount();
         setCallCount(Math.max(localCallCount,remoteCallCount));
+
+        final long localLastUsedTime = getLastUsedTime();
+        final long remoteLastUsedTime = appInfo.getLastUsedTime();
+        setLastUsedTime(Math.max(localLastUsedTime, remoteLastUsedTime));
 
         label=appInfo.getLabel();
         calculateAlternateLabelAndPackageName();

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByLastUsedComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByLastUsedComparator.java
@@ -1,0 +1,28 @@
+package org.ligi.fast.model;
+
+import java.util.Comparator;
+
+public class AppInfoSortByLastUsedComparator implements Comparator<AppInfo> {
+
+    private final Comparator<AppInfo> sortByLabel = new AppInfoSortByLabelComparator();
+
+    @Override
+    public int compare(AppInfo lhs, AppInfo rhs) {
+        int result = 0;
+
+        if (lhs.getLastUsedTime() == rhs.getLastUsedTime()) {
+            result = sortByLabel.compare(lhs, rhs);
+        } else if (lhs.getLastUsedTime() < rhs.getLastUsedTime()) {
+            result = 1;
+        } else if (lhs.getLastUsedTime() > rhs.getLastUsedTime()) {
+            result = -1;
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        return false;
+    }
+}

--- a/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
+++ b/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
@@ -21,7 +21,7 @@ public class DynamicAppInfoList extends AppInfoList {
     private SortMode currentSortMode = SortMode.UNSORTED;
 
     public enum SortMode {
-        UNSORTED, ALPHABETICAL, MOST_USED
+        UNSORTED, ALPHABETICAL, MOST_USED, LAST_USED
     }
 
     @SuppressWarnings("unchecked")
@@ -59,6 +59,8 @@ public class DynamicAppInfoList extends AppInfoList {
             sorter = new AppInfoSortByLabelComparator();
         } else if (mode.equals(SortMode.MOST_USED)) {
             sorter = new AppInfoSortByMostUsedComparator();
+        } else if (mode.equals(SortMode.LAST_USED)) {
+            sorter = new AppInfoSortByLastUsedComparator();
         }
         sort();
         setQuery(currentQuery); // refresh showing

--- a/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
@@ -108,7 +108,7 @@ public class FASTSettingsActivity extends PreferenceActivity {
         sortPref.setTitle(getString(R.string.sort));
         sortPref.setSummary(getString(R.string.sort_decr));
         sortPref.setEntries(R.array.sort_orders);
-        sortPref.setEntryValues(new CharSequence[]{"unsorted", "alpha", "most_used"});
+        sortPref.setEntryValues(new CharSequence[]{"unsorted", "alpha", "most_used", "last_used"});
         sortPref.setDefaultValue("unsorted");
 
         ListPreference themePref = new ListPreference(this);

--- a/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
@@ -160,12 +160,15 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
             adapter.setSortMode(DynamicAppInfoList.SortMode.ALPHABETICAL);
         } else if (App.getSettings().getSortOrder().equals("most_used")) {
             adapter.setSortMode(DynamicAppInfoList.SortMode.MOST_USED);
+        } else if (App.getSettings().getSortOrder().equals("last_used")) {
+            adapter.setSortMode(DynamicAppInfoList.SortMode.LAST_USED);
         }
     }
 
     public void startItemAtPos(int pos) {
         final AppInfo app = adapter.getItem(pos);
         app.incrementCallCount();
+        app.updateLastUsedTime();
         final Intent intent = app.getIntent();
         intent.setAction(Intent.ACTION_MAIN);
         // set flag so that next start the search app comes up and not the last started App

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -57,5 +57,6 @@
         <item>Unsorted</item>
         <item>Alphabetical</item>
         <item>By usage</item>
+        <item>Last used</item>
     </string-array>
 </resources>

--- a/android/src/test/java/org/ligi/fast/testing/TheAppInfoList.java
+++ b/android/src/test/java/org/ligi/fast/testing/TheAppInfoList.java
@@ -12,11 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TheAppInfoList {
 
-    protected String SERIALIZED_APPINFO = "hash1;;labelTest;;packageNameTest;;activityNameTest;;42";
-    protected String SERIALIZED_APPINFO1 = "hash2;;label1TestBarü;;packageNameTest1;;activityNameTest;;42";
-    protected String SERIALIZED_APPINFO2 = "hash3;;label2TestFoo;;packageNameTest2;;activityNameTest;;42";
-    protected String SERIALIZED_APPINFO3 = "hash4;;label3TestFoo;;packageNameTest3;;activityNameTest;;42";
-    protected String SERIALIZED_APPINFO4 = "hash5;;label4TestFoo;;packageNameTest4;;activityNameTest;;42";
+    protected String SERIALIZED_APPINFO = "hash1;;labelTest;;packageNameTest;;activityNameTest;;42;;0";
+    protected String SERIALIZED_APPINFO1 = "hash2;;label1TestBarü;;packageNameTest1;;activityNameTest;;42;;0";
+    protected String SERIALIZED_APPINFO2 = "hash3;;label2TestFoo;;packageNameTest2;;activityNameTest;;42;;0";
+    protected String SERIALIZED_APPINFO3 = "hash4;;label3TestFoo;;packageNameTest3;;activityNameTest;;42;;0";
+    protected String SERIALIZED_APPINFO4 = "hash5;;label4TestFoo;;packageNameTest4;;activityNameTest;;42;;0";
 
 
     private DynamicAppInfoList tested;
@@ -143,11 +143,11 @@ public class TheAppInfoList {
 
     @Test
     public void testShouldSortAlphabeticalIfRequested() throws Exception {
-        AppInfo appInfo1 = new AppInfo(null, "hash1;;clabel;;packageNameTest;;activityNameTest;;42");
-        AppInfo appInfo2 = new AppInfo(null, "hash2;;aabel1TestBarü;;packageNameTest1;;activityNameTest;;42");
-        AppInfo appInfo3 = new AppInfo(null, "hash3;;Fabel2TestFoo;;packageNameTest2;;activityNameTest;;42");
-        AppInfo appInfo4 = new AppInfo(null, "hash4;;eabel3TestFoo;;packageNameTest3;;activityNameTest;;42");
-        AppInfo appInfo5 = new AppInfo(null, "hash5;;Dbel4TestFoo;;packageNameTest4;;activityNameTest;;42");
+        AppInfo appInfo1 = new AppInfo(null, "hash1;;clabel;;packageNameTest;;activityNameTest;;42;;0");
+        AppInfo appInfo2 = new AppInfo(null, "hash2;;aabel1TestBarü;;packageNameTest1;;activityNameTest;;42;;0");
+        AppInfo appInfo3 = new AppInfo(null, "hash3;;Fabel2TestFoo;;packageNameTest2;;activityNameTest;;42;;0");
+        AppInfo appInfo4 = new AppInfo(null, "hash4;;eabel3TestFoo;;packageNameTest3;;activityNameTest;;42;;0");
+        AppInfo appInfo5 = new AppInfo(null, "hash5;;Dbel4TestFoo;;packageNameTest4;;activityNameTest;;42;;0");
         tested = new DynamicAppInfoList(asList(appInfo1, appInfo2, appInfo3, appInfo4, appInfo5), settings);
 
         tested.setSortMode(DynamicAppInfoList.SortMode.ALPHABETICAL);

--- a/android/src/test/java/org/ligi/fast/testing/TheAppInfoList.java
+++ b/android/src/test/java/org/ligi/fast/testing/TheAppInfoList.java
@@ -156,6 +156,21 @@ public class TheAppInfoList {
     }
 
     @Test
+    public void testShouldSortByLastUsedIfRequested() throws Exception {
+        AppInfo appInfo1 = new AppInfo(null, "hash1;;clabel;;packageNameTest;;activityNameTest;;42;;1428491642");
+        AppInfo appInfo2 = new AppInfo(null, "hash2;;aabel1TestBarü;;packageNameTest1;;activityNameTest;;42;;0");
+        AppInfo appInfo3 = new AppInfo(null, "hash3;;Fabel2TestFoo;;packageNameTest2;;activityNameTest;;42;;0");
+        AppInfo appInfo4 = new AppInfo(null, "hash4;;eabel3TestFoo;;packageNameTest3;;activityNameTest;;42;;1428491633");
+        AppInfo appInfo5 = new AppInfo(null, "hash5;;Dbel4TestFoo;;packageNameTest4;;activityNameTest;;42;;1428491699");
+        tested = new DynamicAppInfoList(asList(appInfo1, appInfo2, appInfo3, appInfo4, appInfo5), settings);
+
+        tested.setSortMode(DynamicAppInfoList.SortMode.LAST_USED);
+
+        // Should sort alphabetically if two AppInfo have the same lastUsedTime
+        assertThat(tested).containsExactly(appInfo5, appInfo1, appInfo4, appInfo2, appInfo3);
+    }
+
+    @Test
     public void testShouldMapWithGapSearch() {
         settings.gapSearch = true;
 

--- a/android/src/withExtras/res/values-it/strings.xml
+++ b/android/src/withExtras/res/values-it/strings.xml
@@ -71,5 +71,6 @@
         <item>Non ordinate</item>
         <item>Ordine alfabetico</item>
         <item>A seconda dell\'uso</item>
+        <item>Ultima usata prima</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Hi, this implement a "last used" sorting mode. It simply keep the last used application at the top, and let it "slide behind" as you use another application. The other applications (the one that you haven't opened yet) are sorted by Alphabetical order, like in the "Most used" sorting.

I've added it in the easiest way that I could think off, aka I've added a Unix Epoch timestamp to AppInfo, to remember when the application was launched, and then compare that. It's pretty much completely based on the "most used" implementation.

I've been using it for a day on my phone and it seems to work fine, also the tests seems to be passing.

This is my first time getting my hand dirty with something on Android (or something Java), so I hope it's fine.

This should close issue #47
