### PR TITLE
add flag to edittext to prevent suggestions bar of keyboard appearing.

### DIFF
--- a/android/src/noExtras/res/layout/main_title.xml
+++ b/android/src/noExtras/res/layout/main_title.xml
@@ -22,7 +22,7 @@
             android:background="@drawable/edittext_bg"
             android:hint="@string/query_hint"
             android:paddingLeft="@dimen/padding_large"
-
+            android:inputType="textNoSuggestions"
             android:textColor="?android:textColor" />
 
         <ImageView

--- a/android/src/withExtras/res/layout/main_title.xml
+++ b/android/src/withExtras/res/layout/main_title.xml
@@ -22,7 +22,7 @@
             android:background="@drawable/edittext_bg"
             android:hint="@string/query_hint"
             android:paddingLeft="@dimen/padding_large"
-
+            android:inputType="textNoSuggestions"
             android:textColor="?android:textColor" />
 
         <ImageView


### PR DESCRIPTION
This save vertical space. We probably don't want to autocorrect app names anyway.