### PR TITLE
Added a setting to move search bar to bottom.

### DIFF
--- a/android/src/main/java/org/ligi/fast/settings/AndroidFASTSettings.java
+++ b/android/src/main/java/org/ligi/fast/settings/AndroidFASTSettings.java
@@ -53,6 +53,10 @@ public class AndroidFASTSettings implements FASTSettings {
         return mSharedPreferences.getBoolean(KEY_TEXTONLY, false);
     }
 
+    public boolean isSearchOnBottomActivated() {
+        return mSharedPreferences.getBoolean(KEY_SEARCHONBOTTOM, false);
+    }
+
     public int getMaxLines() {
         return Integer.parseInt(mSharedPreferences.getString(KEY_MAXLINES, "1"));
     }

--- a/android/src/main/java/org/ligi/fast/settings/FASTSettings.java
+++ b/android/src/main/java/org/ligi/fast/settings/FASTSettings.java
@@ -9,6 +9,7 @@ public interface FASTSettings {
     static final String KEY_SEARCHPKG = "search_pkg";
     static final String KEY_MARKETFORALL = "marketforall";
     static final String KEY_TEXTONLY = "textonly";
+    static final String KEY_SEARCHONBOTTOM = "searchonbottom";
     static final String KEY_MAXLINES = "maxlines";
     static final String KEY_ICONSIZE = "iconsize";
     static final String KEY_UMLAUTCONVERT = "convert_umlauts";
@@ -29,6 +30,8 @@ public interface FASTSettings {
     boolean isMarketForAllActivated();
 
     boolean isTextOnlyActivated();
+
+    boolean isSearchOnBottomActivated();
 
     boolean isIgnoreSpaceAfterQueryActivated();
 

--- a/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
@@ -65,6 +65,12 @@ public class FASTSettingsActivity extends PreferenceActivity {
         textOnly.setSummary(R.string.show_no_icons_pure_text);
         textOnly.setDefaultValue(false);
 
+        CheckBoxPreference searchOnBottom = new CheckBoxPreference(this);
+        searchOnBottom.setKey(FASTSettings.KEY_SEARCHONBOTTOM);
+        searchOnBottom.setTitle(R.string.search_on_bottom);
+        searchOnBottom.setSummary(R.string.search_on_bottom_desc);
+        searchOnBottom.setDefaultValue(false);
+
         CheckBoxPreference finishAfterLaunch = new CheckBoxPreference(this);
         finishAfterLaunch.setKey(FASTSettings.KEY_FINISH_ON_LAUNCH);
         finishAfterLaunch.setTitle("Finish on Launch");
@@ -172,6 +178,8 @@ public class FASTSettingsActivity extends PreferenceActivity {
 
         displayCategory.addPreference(iconSizePref);
         displayCategory.addPreference(maxLinesPref);
+
+        displayCategory.addPreference(searchOnBottom);
 
         behaviourCategory.addPreference(doLaunchSingleCheckBox);
         behaviourCategory.addPreference(doSearchInPackage);

--- a/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
@@ -57,11 +57,7 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
 
         super.onCreate(savedInstanceState);
 
-        requestWindowFeature(Window.FEATURE_CUSTOM_TITLE);
-
-        setContentView(R.layout.activity_search);
-
-        getWindow().setFeatureInt(Window.FEATURE_CUSTOM_TITLE, R.layout.main_title);
+        dealWithUserPreferencesRegardingSearchBarPlacement();
 
         appInfoListStore = new AppInfoListStore(this);
 
@@ -228,6 +224,19 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
             default:
                 return R.dimen.cell_size;
         }
+    }
+
+
+    private void dealWithUserPreferencesRegardingSearchBarPlacement() {
+        if (App.getSettings().isSearchOnBottomActivated()) {
+            requestWindowFeature(Window.FEATURE_NO_TITLE);
+            setContentView(R.layout.activity_search_alt);
+        } else {
+            requestWindowFeature(Window.FEATURE_CUSTOM_TITLE);
+            setContentView(R.layout.activity_search);
+            getWindow().setFeatureInt(Window.FEATURE_CUSTOM_TITLE, R.layout.main_title);
+        }
+
     }
 
     private void dealWithUserPreferencesRegardingSoftKeyboard() {

--- a/android/src/main/res/layout/activity_search_alt.xml
+++ b/android/src/main/res/layout/activity_search_alt.xml
@@ -1,0 +1,24 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <GridView
+        android:id="@+id/listView"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:columnWidth="@dimen/cell_size"
+        android:gravity="center"
+        android:horizontalSpacing="1dp"
+        android:numColumns="auto_fit"
+        android:stretchMode="columnWidth"
+        android:verticalSpacing="10dp"
+        android:padding="3dp"
+        android:layout_above="@+id/maintitle"/>
+
+    <include android:layout_width="fill_parent"
+             android:layout_height="@dimen/actionbar_height"
+             android:layout_alignParentBottom="true"
+             layout="@layout/main_title"/>
+
+</RelativeLayout>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="remove_cache_descr">Force FAST to reset app list and history</string>
     <string name="icon_resolution_title">Icon Resolution</string>
     <string name="icon_resolution_summary">More speed or more pixels?</string>
+    <string name="search_on_bottom">Search bar on bottom</string>
+    <string name="search_on_bottom_desc">Moves the search bar to the bottom of the screen</string>
     <string-array name="sizes">
         <item>Tiny</item>
         <item>Small</item>

--- a/android/src/noExtras/res/layout/main_title.xml
+++ b/android/src/noExtras/res/layout/main_title.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/maintitle"
     android:layout_width="fill_parent"
     android:layout_height="@dimen/actionbar_height"
     android:orientation="vertical">

--- a/android/src/withExtras/res/layout/main_title.xml
+++ b/android/src/withExtras/res/layout/main_title.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/maintitle"
     android:layout_width="fill_parent"
     android:layout_height="@dimen/actionbar_height"
     android:orientation="vertical">


### PR DESCRIPTION
Ideally should be done without an alternative layout, but this seems to work well on my device.
Any suggestions on how to do this more cleanly would be appreciated, perhaps using a viewstub or similar, but this would require rewriting activity_search.xml and possibly messing up the existing behaviour of the app.
