### PR TITLE
CATEGORY_LAUNCHER and Hide + Pin functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@ Just type in a fraction of the name of the App you want to launch - most of the 
 Howto
 =====
 
-A single click launches the App - a long click gives you 3 Options:
+A single click launches the App - a long click gives you 6 Options:
  1. Go to the App details
- 2. Open the App in Google Play
- 3. Open the App as a Notification for FAST access at a later time
+ 2. Customize its Label or create additional entries for the App
+ 3. Pin the App to top
+ 4. Hide the App
+ 5. Open the App as a Notification for FAST access at a later time
+ 6. Open the App in Google Play
 
 
 License
@@ -27,7 +30,7 @@ The App is <a href="http://gplv3.fsf.org/">GPLv3</a>
 Credits
 =======
 
-Thanks to  <a href="https://github.com/talexop">talexop</a>, <a href="https://github.com/pserwylo">Peter Serwylo</a> and <a href="http://www.petervasil.net">Peter Vasil</a> for contributions!
+Thanks to <a href="https://github.com/talexop">talexop</a>, <a href="https://github.com/pserwylo">Peter Serwylo</a>, <a href="http://www.petervasil.net">Peter Vasil</a>, <a href="https://github.com/ShadowKyogre">ShadowKyogre</a> and <a href="https://github.com/SebiderSushi">SebiderSushi</a> for contributions!
 
 Questions
 =========

--- a/android/src/androidTest/java/org/ligi/fast/testing/AndroidTestMutableFastSettings.java
+++ b/android/src/androidTest/java/org/ligi/fast/testing/AndroidTestMutableFastSettings.java
@@ -83,5 +83,8 @@ public class AndroidTestMutableFastSettings implements FASTSettings {
         return Integer.parseInt(AndroidFASTSettings.DEFUAULT_ICON_RESOLUTION);
     }
 
-
+    @Override
+    public boolean isShowHiddenActivated() {
+        return false;
+    }
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:launchMode="singleTask"
             android:stateNotNeeded="true"
             android:excludeFromRecents="true"
-            >
+            android:configChanges="orientation">
 
             <meta-data
                 android:name="com.android.systemui.action_assist_icon"

--- a/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
+++ b/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
@@ -47,10 +47,7 @@ public class BaseAppGatherAsyncTask extends AsyncTask<Void, AppInfo, Void> {
                     // we saved the package list. An alternative would be to save the package list
                     // each time we leave
                     if (oldAppList != null) {
-                        for(AppInfo oldInfo : appInfoList) {
-                            //oldInfo doesn't actually hold new stuff!
-                            Log.d(oldInfo.getActivityName()+"("+actAppInfo.getPinMode()+"|"+oldInfo.getPinMode() +
-                                    "," + actAppInfo.getCallCount() + "|" + oldInfo.getCallCount()+")");
+                        for(AppInfo oldInfo : oldAppList) {
                             if (oldInfo.getActivityName().equals(actAppInfo.getActivityName())) {
                                 if (oldInfo.getLabelMode() == 2) {
                                     appInfoList.add(oldInfo);

--- a/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
+++ b/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
@@ -48,8 +48,12 @@ public class BaseAppGatherAsyncTask extends AsyncTask<Void, AppInfo, Void> {
                     // each time we leave
                     if (oldAppList != null) {
                         for(AppInfo oldInfo : appInfoList) {
+                            //oldInfo doesn't actually hold new stuff!
+                            Log.d(oldInfo.getActivityName()+"("+actAppInfo.getPinMode()+"|"+oldInfo.getPinMode() +
+                                    "," + actAppInfo.getCallCount() + "|" + oldInfo.getCallCount()+")");
                             if (oldInfo.getActivityName().equals(actAppInfo.getActivityName())) {
                                 actAppInfo.setCallCount(oldInfo.getCallCount());
+                                actAppInfo.setPinMode(oldInfo.getPinMode());
                                 break;
                             }
                         }

--- a/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
+++ b/android/src/main/java/org/ligi/fast/background/BaseAppGatherAsyncTask.java
@@ -52,9 +52,14 @@ public class BaseAppGatherAsyncTask extends AsyncTask<Void, AppInfo, Void> {
                             Log.d(oldInfo.getActivityName()+"("+actAppInfo.getPinMode()+"|"+oldInfo.getPinMode() +
                                     "," + actAppInfo.getCallCount() + "|" + oldInfo.getCallCount()+")");
                             if (oldInfo.getActivityName().equals(actAppInfo.getActivityName())) {
-                                actAppInfo.setCallCount(oldInfo.getCallCount());
-                                actAppInfo.setPinMode(oldInfo.getPinMode());
-                                break;
+                                if (oldInfo.getLabelMode() == 2) {
+                                    appInfoList.add(oldInfo);
+                                } else {
+                                    actAppInfo.setCallCount(oldInfo.getCallCount());
+                                    actAppInfo.setPinMode(oldInfo.getPinMode());
+                                    actAppInfo.setLabelMode(oldInfo.getLabelMode());
+                                    actAppInfo.setOverrideLabel(oldInfo.getOverrideLabel());
+                                }
                             }
                         }
                     }

--- a/android/src/main/java/org/ligi/fast/model/AppInfo.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfo.java
@@ -29,6 +29,7 @@ public class AppInfo {
     private long installTime;
     private int callCount;
     private boolean isValid = true;
+    private int pinMode;
 
     private final AppIconCache iconCache;
 
@@ -51,6 +52,13 @@ public class AppInfo {
 
                 if (app_info_str_split.length > 5) {
                     installTime = Long.parseLong(app_info_str_split[5]);
+                }
+
+                if (app_info_str_split.length < 6) {
+                    pinMode = 0;
+                }
+                else {
+                    pinMode = Integer.parseInt(app_info_str_split[5]);
                 }
 
                 calculateAlternateLabelAndPackageName();
@@ -116,7 +124,7 @@ public class AppInfo {
 
     public String toCacheString() {
         return hash + SEPARATOR + label + SEPARATOR + packageName +
-               SEPARATOR + activityName + SEPARATOR + callCount + SEPARATOR + installTime;
+               SEPARATOR + activityName + SEPARATOR + callCount + SEPARATOR + installTime + SEPARATOR + pinMode;
     }
 
     private String calculateTheHash() {
@@ -207,8 +215,22 @@ public class AppInfo {
         final int localCallCount = getCallCount();
         final int remoteCallCount = appInfo.getCallCount();
         setCallCount(Math.max(localCallCount, remoteCallCount));
+        if (appInfo.getPinMode() != 0) {
+            setPinMode(appInfo.getPinMode());
+        }
+        else {
+            setPinMode(getPinMode());
+        }
 
         label = appInfo.getLabel();
         calculateAlternateLabelAndPackageName();
+    }
+
+    public int getPinMode() {
+        return pinMode;
+    }
+
+    public void setPinMode(int pinMode) {
+        this.pinMode = pinMode;
     }
 }

--- a/android/src/main/java/org/ligi/fast/model/AppInfo.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfo.java
@@ -22,6 +22,7 @@ public class AppInfo {
 
     private String label;
     private String alternateLabel;
+    private String overrideLabel;
     private String packageName;
     private String alternatePackageName;
     private String activityName;
@@ -29,7 +30,8 @@ public class AppInfo {
     private long installTime;
     private int callCount;
     private boolean isValid = true;
-    private int pinMode;
+    private int pinMode = 0;
+    private int labelMode = 0;
 
     private final AppIconCache iconCache;
 
@@ -52,13 +54,15 @@ public class AppInfo {
 
                 if (app_info_str_split.length > 5) {
                     installTime = Long.parseLong(app_info_str_split[5]);
-                }
-
-                if (app_info_str_split.length < 6) {
-                    pinMode = 0;
-                }
-                else {
-                    pinMode = Integer.parseInt(app_info_str_split[5]);
+                    if (app_info_str_split.length > 6) {
+                        pinMode = Integer.parseInt(app_info_str_split[6]);
+                        if (app_info_str_split.length > 7) {
+                            labelMode = Integer.parseInt(app_info_str_split[7]);
+                            if (app_info_str_split.length > 8) {
+                                overrideLabel = app_info_str_split[8];
+                            }
+                        }
+                    }
                 }
 
                 calculateAlternateLabelAndPackageName();
@@ -124,7 +128,9 @@ public class AppInfo {
 
     public String toCacheString() {
         return hash + SEPARATOR + label + SEPARATOR + packageName +
-               SEPARATOR + activityName + SEPARATOR + callCount + SEPARATOR + installTime + SEPARATOR + pinMode;
+                SEPARATOR + activityName + SEPARATOR + callCount +
+                SEPARATOR + installTime + SEPARATOR + pinMode +
+                SEPARATOR + labelMode + SEPARATOR + overrideLabel;
     }
 
     private String calculateTheHash() {
@@ -175,8 +181,20 @@ public class AppInfo {
         return packageName;
     }
 
+    /**
+     * Please keep in mind that this might now return unexpected values
+     * @return the user-set label if it is set, default otherwise
+     */
+    public String getDisplayLabel() {
+        if (labelMode == 0) {
+            return label;
+        } else {
+            return overrideLabel;
+        }
+    }
+
     public String getLabel() {
-        return label;
+        return this.label;
     }
 
     public int getCallCount() {
@@ -203,6 +221,18 @@ public class AppInfo {
         return hash;
     }
 
+    /**
+     * Please keep in mind that this might now return unexpected values
+     * @return the user-set label if it is set, alternateLabel otherwise
+     */
+    public String getAlternateDisplayLabel() {
+        if (labelMode == 0) {
+            return alternateLabel;
+        } else {
+            return overrideLabel;
+        }
+    }
+
     public String getAlternateLabel() {
         return alternateLabel;
     }
@@ -222,6 +252,11 @@ public class AppInfo {
             setPinMode(getPinMode());
         }
 
+        if (appInfo.getLabelMode() == 1) {
+            setLabelMode(1);
+            setOverrideLabel(appInfo.getOverrideLabel());
+        }
+
         label = appInfo.getLabel();
         calculateAlternateLabelAndPackageName();
     }
@@ -232,5 +267,21 @@ public class AppInfo {
 
     public void setPinMode(int pinMode) {
         this.pinMode = pinMode;
+    }
+
+    public int getLabelMode() {
+        return this.labelMode;
+    }
+
+    public void setLabelMode(int mode) {
+        this.labelMode = mode;
+    }
+
+    public String getOverrideLabel() {
+        return overrideLabel;
+    }
+
+    public void setOverrideLabel(String label) {
+        this.overrideLabel = label;
     }
 }

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByLabelComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByLabelComparator.java
@@ -5,11 +5,19 @@ import java.util.Locale;
 
 class AppInfoSortByLabelComparator implements Comparator<AppInfo> {
 
+    private final Comparator<AppInfo> sortByPin = new AppInfoSortByPinComparator();
+
     @Override
     public int compare(AppInfo lhs, AppInfo rhs) {
-        final String lhsLowerCaseLabel = lhs.getLabel().toLowerCase(Locale.ENGLISH);
-        final String rhsLowerCaseLabel = rhs.getLabel().toLowerCase(Locale.ENGLISH);
-        return lhsLowerCaseLabel.compareTo(rhsLowerCaseLabel);
+        int result = sortByPin.compare(lhs, rhs);
+        if (result == 0) {
+            final String lhsLowerCaseLabel = lhs.getLabel().toLowerCase(Locale.ENGLISH);
+            final String rhsLowerCaseLabel = rhs.getLabel().toLowerCase(Locale.ENGLISH);
+            return lhsLowerCaseLabel.compareTo(rhsLowerCaseLabel);
+        }
+        else {
+            return result;
+        }
     }
 
 }

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByLabelComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByLabelComparator.java
@@ -11,8 +11,8 @@ class AppInfoSortByLabelComparator implements Comparator<AppInfo> {
     public int compare(AppInfo lhs, AppInfo rhs) {
         int result = sortByPin.compare(lhs, rhs);
         if (result == 0) {
-            final String lhsLowerCaseLabel = lhs.getLabel().toLowerCase(Locale.ENGLISH);
-            final String rhsLowerCaseLabel = rhs.getLabel().toLowerCase(Locale.ENGLISH);
+            final String lhsLowerCaseLabel = lhs.getDisplayLabel().toLowerCase(Locale.ENGLISH);
+            final String rhsLowerCaseLabel = rhs.getDisplayLabel().toLowerCase(Locale.ENGLISH);
             return lhsLowerCaseLabel.compareTo(rhsLowerCaseLabel);
         }
         else {

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByMostUsedComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByMostUsedComparator.java
@@ -1,21 +1,28 @@
 package org.ligi.fast.model;
 
 import java.util.Comparator;
+import java.util.Locale;
 
 public class AppInfoSortByMostUsedComparator implements Comparator<AppInfo> {
 
-    private final Comparator<AppInfo> sortByLabel = new AppInfoSortByLabelComparator();
+    //private final Comparator<AppInfo> sortByLabel = new AppInfoSortByLabelComparator();
+    private final Comparator<AppInfo> sortByPin = new AppInfoSortByPinComparator();
 
     @Override
     public int compare(AppInfo lhs, AppInfo rhs) {
-        int result = 0;
+        int result = sortByPin.compare(lhs, rhs);
 
-        if (lhs.getCallCount() == rhs.getCallCount()) {
-            result = sortByLabel.compare(lhs, rhs);
-        } else if (lhs.getCallCount() < rhs.getCallCount()) {
-            result = 1;
-        } else if (lhs.getCallCount() > rhs.getCallCount()) {
-            result = -1;
+        if (result == 0) {
+            if (lhs.getCallCount() == rhs.getCallCount()) {
+                //result = sortByLabel.compare(lhs, rhs);
+                final String lhsLowerCaseLabel = lhs.getLabel().toLowerCase(Locale.ENGLISH);
+                final String rhsLowerCaseLabel = rhs.getLabel().toLowerCase(Locale.ENGLISH);
+                result = lhsLowerCaseLabel.compareTo(rhsLowerCaseLabel);
+            } else if (lhs.getCallCount() < rhs.getCallCount()) {
+                result = 1;
+            } else if (lhs.getCallCount() > rhs.getCallCount()) {
+                result = -1;
+            }
         }
 
         return result;

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByMostUsedComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByMostUsedComparator.java
@@ -15,8 +15,8 @@ public class AppInfoSortByMostUsedComparator implements Comparator<AppInfo> {
         if (result == 0) {
             if (lhs.getCallCount() == rhs.getCallCount()) {
                 //result = sortByLabel.compare(lhs, rhs);
-                final String lhsLowerCaseLabel = lhs.getLabel().toLowerCase(Locale.ENGLISH);
-                final String rhsLowerCaseLabel = rhs.getLabel().toLowerCase(Locale.ENGLISH);
+                final String lhsLowerCaseLabel = lhs.getDisplayLabel().toLowerCase(Locale.ENGLISH);
+                final String rhsLowerCaseLabel = rhs.getDisplayLabel().toLowerCase(Locale.ENGLISH);
                 result = lhsLowerCaseLabel.compareTo(rhsLowerCaseLabel);
             } else if (lhs.getCallCount() < rhs.getCallCount()) {
                 result = 1;

--- a/android/src/main/java/org/ligi/fast/model/AppInfoSortByPinComparator.java
+++ b/android/src/main/java/org/ligi/fast/model/AppInfoSortByPinComparator.java
@@ -1,0 +1,23 @@
+package org.ligi.fast.model;
+
+import android.util.Log;
+
+import java.util.Comparator;
+import java.util.Locale;
+
+class AppInfoSortByPinComparator implements Comparator<AppInfo> {
+
+    @Override
+    public int compare(AppInfo lhs, AppInfo rhs) {
+        if (lhs.getPinMode() == rhs.getPinMode()) {
+            return 0;
+        }
+        else if (lhs.getPinMode() < rhs.getPinMode()) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+
+}

--- a/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
+++ b/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
@@ -62,6 +62,8 @@ public class DynamicAppInfoList extends AppInfoList {
             sorter = new AppInfoSortByMostUsedComparator();
         } else if (mode.equals(SortMode.LAST_INSTALLED)) {
             sorter = new AppInfoSortByLastInstalled();
+        } else {
+            sorter = new AppInfoSortByPinComparator();
         }
         setQuery(currentQuery); // refresh showing
     }
@@ -100,6 +102,10 @@ public class DynamicAppInfoList extends AppInfoList {
     }
 
     private boolean appInfoMatchesQuery(AppInfo info, String query) {
+        if (!settings.isShowHiddenActivated() && info.getPinMode() == -1) {
+            return false;
+        }
+
         if (info.getLabel().toLowerCase(Locale.ENGLISH).contains(query)) {
             return true;
         }

--- a/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
+++ b/android/src/main/java/org/ligi/fast/model/DynamicAppInfoList.java
@@ -44,7 +44,14 @@ public class DynamicAppInfoList extends AppInfoList {
         for (AppInfo app : pkgAppsListAll) {
             final AppInfo appWithHash = getAppWithHash(app.getHash(), backingAppInfoList);
             if (appWithHash != null) {
-                appWithHash.mergeSafe(app);
+                if (app.getLabelMode() == 2) {
+                    final AppInfoList aliasesWithHash = getAliasesWithHash(app.getHash(), backingAppInfoList);
+                    if (!aliasesWithHash.contains(app)) {
+                        backingAppInfoList.add(app);
+                    }
+                } else {
+                    appWithHash.mergeSafe(app);
+                }
             } else {
                 backingAppInfoList.add(app);
             }
@@ -106,13 +113,13 @@ public class DynamicAppInfoList extends AppInfoList {
             return false;
         }
 
-        if (info.getLabel().toLowerCase(Locale.ENGLISH).contains(query)) {
+        if (info.getDisplayLabel().toLowerCase(Locale.ENGLISH).contains(query)) {
             return true;
         }
 
         if (settings.isUmlautConvertActivated()
-                && info.getAlternateLabel() != null
-                && info.getAlternateLabel().toLowerCase(Locale.ENGLISH).contains(query)) {
+                && info.getAlternateDisplayLabel() != null
+                && info.getAlternateDisplayLabel().toLowerCase(Locale.ENGLISH).contains(query)) {
             return true;
         }
 
@@ -139,7 +146,7 @@ public class DynamicAppInfoList extends AppInfoList {
 
     private boolean isGapSearchActivateAndTrueForQuery(AppInfo info, String query) {
         if (settings.isGapSearchActivated()) {
-            final String appLabelLowerCase = info.getLabel().toLowerCase(Locale.ENGLISH);
+            final String appLabelLowerCase = info.getDisplayLabel().toLowerCase(Locale.ENGLISH);
             final int diffLength = appLabelLowerCase.length() - query.length();
             final int threshold = diffLength > 0 ? diffLength : 0;
 
@@ -152,11 +159,21 @@ public class DynamicAppInfoList extends AppInfoList {
 
     private static AppInfo getAppWithHash(String hash, List<AppInfo> appInfoList) {
         for (AppInfo info : appInfoList) {
-            if (info.getHash().equals(hash)) {
+            if (info.getLabelMode() < 2 && info.getHash().equals(hash)) {
                 return info;
             }
         }
         return null;
+    }
+
+    private static AppInfoList getAliasesWithHash(String hash, List<AppInfo> appInfoList) {
+        AppInfoList aliasesWithHash = new AppInfoList();
+        for (AppInfo info : appInfoList) {
+            if (info.getLabelMode() == 2 && info.getHash().equals(hash)) {
+                aliasesWithHash.add(info);
+            }
+        }
+        return aliasesWithHash;
     }
 
     public List<AppInfo> getBackingAppInfoList() {

--- a/android/src/main/java/org/ligi/fast/settings/AndroidFASTSettings.java
+++ b/android/src/main/java/org/ligi/fast/settings/AndroidFASTSettings.java
@@ -78,4 +78,8 @@ public class AndroidFASTSettings implements FASTSettings {
         return mSharedPreferences.getBoolean(KEY_GAP_SEARCH, true);
     }
 
+    public boolean isShowHiddenActivated() {
+        return mSharedPreferences.getBoolean(KEY_SHOW_HIDDEN, false);
+    }
+
 }

--- a/android/src/main/java/org/ligi/fast/settings/FASTSettings.java
+++ b/android/src/main/java/org/ligi/fast/settings/FASTSettings.java
@@ -19,6 +19,7 @@ public interface FASTSettings {
     static final String KEY_FINISH_ON_LAUNCH = "finish_on_LAUNCH";
     static final String KEY_GAP_SEARCH = "gap_search";
     static final String KEY_ICONRES = "icon_res";
+    static final String KEY_SHOW_HIDDEN = "show_hidden";
 
     boolean isLaunchSingleActivated();
 
@@ -47,5 +48,7 @@ public interface FASTSettings {
     boolean isFinishOnLaunchEnabled();
 
     boolean isGapSearchActivated();
+
+    boolean isShowHiddenActivated();
 
 }

--- a/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
+++ b/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
@@ -48,6 +48,35 @@ public class AppActionDialogBuilder extends AlertDialog.Builder {
             }
         }));
 
+        fkt_map.add(new LabelAndCode(context.getString(R.string.change_label), new Runnable() {
+            @Override
+            public void run() {
+                new SetLabelDialogBuilder(context, app_info).show();
+                ((SearchActivity) context).configureAdapter();
+            }
+        }));
+
+        if (app_info.getLabelMode() == 1) {
+            fkt_map.add(new LabelAndCode(context.getString(R.string.reset_label), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setOverrideLabel(null);
+                    app_info.setLabelMode(0);
+                    ((SearchActivity) context).configureAdapter();
+                }
+            }));
+        }
+
+        if (app_info.getLabelMode() == 2) {
+            fkt_map.add(new LabelAndCode(context.getString(R.string.remove_alias), new Runnable() {
+                @Override
+                public void run() {
+                    ((SearchActivity) context).removeEntry(app_info);
+                    ((SearchActivity) context).configureAdapter();
+                }
+            }));
+        }
+
         if (app_info.getPinMode() == 0) {
             fkt_map.add(new LabelAndCode(context.getString(R.string.pin_app), new Runnable() {
                 @Override
@@ -205,7 +234,7 @@ public class AppActionDialogBuilder extends AlertDialog.Builder {
 
             PendingIntent intent = PendingIntent.getActivity(context, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-            final String title = app_info.getLabel();
+            final String title = app_info.getDisplayLabel();
             NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             final Notification notification;
 
@@ -252,14 +281,14 @@ public class AppActionDialogBuilder extends AlertDialog.Builder {
         @Override
         public void run() {
             final Intent shortcutIntent = new Intent();
-            shortcutIntent.setClassName(app_info.getPackageName(), app_info.getLabel());
+            shortcutIntent.setClassName(app_info.getPackageName(), app_info.getDisplayLabel());
             shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             shortcutIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             shortcutIntent.addCategory(Intent.ACTION_PICK_ACTIVITY);
             final Intent create_shortcut_intent = new Intent();
             create_shortcut_intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent);
             // Sets the custom shortcut's title
-            create_shortcut_intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, app_info.getLabel());
+            create_shortcut_intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, app_info.getDisplayLabel());
 
             final BitmapDrawable bd = (BitmapDrawable) (app_info.getIcon());
             Bitmap newBitmap = bd.getBitmap();

--- a/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
+++ b/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
@@ -48,6 +48,55 @@ public class AppActionDialogBuilder extends AlertDialog.Builder {
             }
         }));
 
+        if (app_info.getPinMode() == 0) {
+            fkt_map.add(new LabelAndCode(context.getString(R.string.pin_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(1);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+            fkt_map.add(new LabelAndCode(context.getString(R.string.hide_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(-1);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+        }
+        else if (app_info.getPinMode() == 1) {
+            fkt_map.add(new LabelAndCode(context.getString(R.string.unpin_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(0);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+            fkt_map.add(new LabelAndCode(context.getString(R.string.hide_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(-1);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+        }
+        else {
+            fkt_map.add(new LabelAndCode(context.getString(R.string.pin_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(1);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+            fkt_map.add(new LabelAndCode(context.getString(R.string.unhide_app), new Runnable() {
+                @Override
+                public void run() {
+                    app_info.setPinMode(0);
+                    ((SearchActivity)context).configureAdapter();
+                }
+            }));
+        }
+
         fkt_map.add(new LabelAndCode(context.getString(R.string.open_as_notification), new OpenAsNotificationRunnable()));
 
         if (App.getSettings().isMarketForAllActivated() || isMarketApp()) {

--- a/android/src/main/java/org/ligi/fast/ui/AppInfoAdapter.java
+++ b/android/src/main/java/org/ligi/fast/ui/AppInfoAdapter.java
@@ -93,7 +93,7 @@ public class AppInfoAdapter extends BaseAdapter {
         if (maxLines==0) {
             labelView.setVisibility(View.GONE);
         } else {
-            labelView.setMaxLines(maxLines);
+            labelView.setLines(maxLines);
             labelView.setVisibility(View.VISIBLE);
         }
 

--- a/android/src/main/java/org/ligi/fast/ui/AppInfoAdapter.java
+++ b/android/src/main/java/org/ligi/fast/ui/AppInfoAdapter.java
@@ -97,7 +97,7 @@ public class AppInfoAdapter extends BaseAdapter {
             labelView.setVisibility(View.VISIBLE);
         }
 
-        String label = actAppInfo.getLabel();
+        String label = actAppInfo.getDisplayLabel();
         String highlight_label = label;
 
         int query_index = label.toLowerCase(Locale.ENGLISH).indexOf(appInfoList.getCurrentQuery());
@@ -124,10 +124,10 @@ public class AppInfoAdapter extends BaseAdapter {
                     label.length());
         } else if (App.getSettings().isGapSearchActivated()) {
 
-            final ArrayList<Integer> matchedIndices = StringUtils.getMatchedIndices(actAppInfo.getLabel(),appInfoList.getCurrentQuery());
+            final ArrayList<Integer> matchedIndices = StringUtils.getMatchedIndices(actAppInfo.getDisplayLabel(),appInfoList.getCurrentQuery());
             if (matchedIndices.size()==appInfoList.getCurrentQuery().length()) {
                 // highlight single characters of query in label for gap matched strings
-                label = actAppInfo.getLabel();
+                label = actAppInfo.getDisplayLabel();
             } // otherwise must be in package
 
             highlight_label="";

--- a/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/FASTSettingsActivity.java
@@ -65,6 +65,12 @@ public class FASTSettingsActivity extends PreferenceActivity {
         textOnly.setSummary(R.string.show_no_icons_pure_text);
         textOnly.setDefaultValue(false);
 
+        CheckBoxPreference noHidden = new CheckBoxPreference(this);
+        noHidden.setKey(FASTSettings.KEY_SHOW_HIDDEN);
+        noHidden.setTitle(R.string.show_even_hidden);
+        noHidden.setSummary(R.string.show_even_hidden_summary);
+        noHidden.setDefaultValue(false);
+
         CheckBoxPreference finishAfterLaunch = new CheckBoxPreference(this);
         finishAfterLaunch.setKey(FASTSettings.KEY_FINISH_ON_LAUNCH);
         finishAfterLaunch.setTitle("Finish on Launch");
@@ -178,6 +184,7 @@ public class FASTSettingsActivity extends PreferenceActivity {
         behaviourCategory.addPreference(finishAfterLaunch);
         behaviourCategory.addPreference(marketForAllApps);
         displayCategory.addPreference(textOnly);
+        displayCategory.addPreference(noHidden);
         behaviourCategory.addPreference(sortPref);
         behaviourCategory.addPreference(ignoreSpace);
         behaviourCategory.addPreference(autoShowKeyboard);

--- a/android/src/main/java/org/ligi/fast/ui/LoadingDialog.java
+++ b/android/src/main/java/org/ligi/fast/ui/LoadingDialog.java
@@ -47,7 +47,7 @@ public class LoadingDialog extends Activity {
                 getProgressBar().setProgress(actAppIndex);
 
                 setIcon(values[0].getIcon());
-                setText(values[0].getLabel());
+                setText(values[0].getDisplayLabel());
 
             }
 

--- a/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
@@ -330,4 +330,12 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         App.packageChangedListener = null;
         super.onPause();
     }
+
+    public void addEntry(AppInfo new_entry) {
+        appInfoList.getBackingAppInfoList().add(new_entry);
+    }
+
+    public void removeEntry(AppInfo entry) {
+        appInfoList.getBackingAppInfoList().remove(entry);
+    }
 }

--- a/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
@@ -155,7 +155,7 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         }
     }
 
-    private void configureAdapter() {
+    public void configureAdapter() {
         if (App.getSettings().getSortOrder().startsWith("alpha")) {
             adapter.setSortMode(DynamicAppInfoList.SortMode.ALPHABETICAL);
         } else if (App.getSettings().getSortOrder().equals("most_used")) {
@@ -190,6 +190,7 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         }
 
         if (App.getSettings().isFinishOnLaunchEnabled()) {
+            Log.i(App.LOG_TAG, "Finished early.");
             finish();
         }
     }
@@ -219,6 +220,7 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         configureAdapter();
 
         final String iconSize = App.getSettings().getIconSize();
+
         gridView.setColumnWidth((int) getResources().getDimension(getWidthByIconSize(iconSize)));
     }
 
@@ -328,6 +330,4 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         App.packageChangedListener = null;
         super.onPause();
     }
-
-
 }

--- a/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
+++ b/android/src/main/java/org/ligi/fast/ui/SearchActivity.java
@@ -174,6 +174,7 @@ public class SearchActivity extends Activity implements App.PackageChangedListen
         intent.setAction(Intent.ACTION_MAIN);
         // set flag so that next start the search app comes up and not the last started App
         intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
         Log.d(App.LOG_TAG, "Starting " + app.getActivityName() + " (and incremented call count to " + app.getCallCount() + ")");
 
         try {

--- a/android/src/main/java/org/ligi/fast/ui/SetLabelDialogBuilder.java
+++ b/android/src/main/java/org/ligi/fast/ui/SetLabelDialogBuilder.java
@@ -1,0 +1,85 @@
+package org.ligi.fast.ui;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.LinearLayout;
+
+import org.ligi.axt.helpers.ViewHelper;
+import org.ligi.fast.R;
+import org.ligi.fast.model.AppInfo;
+
+class SetLabelDialogBuilder extends AlertDialog.Builder {
+
+    SetLabelDialogBuilder(final Context context, final AppInfo app_info) {
+        super(context);
+
+        setTitle("" + String.format(context.getString(R.string.change_label_of), app_info.getDisplayLabel()));
+
+        LinearLayout layout = (LinearLayout) LayoutInflater.from(context).inflate(R.layout.dialog_set_label, null);
+        setView(layout);
+
+        final CheckBox newEntry = (CheckBox) layout.findViewById(R.id.checkBox_newEntry);
+        final CheckBox hideOriginalEntry = (CheckBox) layout.findViewById(R.id.checkBox_hideOriginalEntry);
+        final EditText label = (EditText) layout.findViewById(R.id.editText_newLabel);
+        ImageButton clear = (ImageButton) layout.findViewById(R.id.imageButton_clear);
+
+        newEntry.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                hideOriginalEntry.setVisibility(b ? View.VISIBLE : View.GONE);
+            }
+        });
+
+        hideOriginalEntry.setChecked(app_info.getPinMode() == -1);
+
+        label.setHint(app_info.getLabel());
+        label.setText(app_info.getDisplayLabel());
+        label.setSelection(label.length());
+        label.requestFocus();
+        label.postDelayed(new Runnable() {
+
+            @Override
+            public void run() {
+                new ViewHelper(label).showKeyboard();
+            }
+        }, 200);
+
+        clear.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                label.setText("");
+            }
+        });
+
+        setPositiveButton(R.string.change_label, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                if (newEntry.isChecked()) {
+                    AppInfo new_entry = new AppInfo(context, app_info.toCacheString());
+                    new_entry.setOverrideLabel(label.getText().toString());
+                    new_entry.setLabelMode(2);
+                    ((SearchActivity) context).addEntry(new_entry);
+                    if (hideOriginalEntry.isChecked()) {
+                        app_info.setPinMode(-1);
+                    }
+                } else {
+                    app_info.setOverrideLabel(label.getText().toString());
+                    if (app_info.getLabelMode() == 0) {
+                        app_info.setLabelMode(1);
+                    }
+                }
+
+                ((SearchActivity) context).configureAdapter();
+            }
+        });
+
+        setNeutralButton(R.string.cancel, null);
+    }
+}

--- a/android/src/main/res/layout/dialog_set_label.xml
+++ b/android/src/main/res/layout/dialog_set_label.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <CheckBox
+        android:id="@+id/checkBox_newEntry"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/as_new_entry" />
+
+    <CheckBox
+        android:id="@+id/checkBox_hideOriginalEntry"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/hide_original_entry"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/editText_newLabel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:inputType="text"
+            android:lines="1" />
+
+        <ImageButton
+            android:id="@+id/imageButton_clear"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="8dp"
+            android:layout_marginLeft="3dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginStart="3dp"
+            android:background="@android:drawable/ic_input_delete" />
+    </LinearLayout>
+</LinearLayout>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -14,6 +14,14 @@
     <string name="open_as_notification">Open as Notification</string>
     <string name="query_hint">Enter query here</string>
     <string name="text_only">Only show app names</string>
+    <string name="no_hidden">Show hidden apps</string>
+    <string name="cancel">Cancel</string>
+    <string name="change_label">Change Label</string>
+    <string name="change_label_of">Change Label of %s</string>
+    <string name="reset_label">Reset Label</string>
+    <string name="remove_alias">Remove Alias</string>
+    <string name="as_new_entry">Add as new entry</string>
+    <string name="hide_original_entry">Hide original entry</string>
     <string name="hide_app">Hide</string>
     <string name="unhide_app">Unhide</string>
     <string name="app_gone">This App is gone :-(</string>

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -14,8 +14,12 @@
     <string name="open_as_notification">Open as Notification</string>
     <string name="query_hint">Enter query here</string>
     <string name="text_only">Only show app names</string>
+    <string name="hide_app">Hide</string>
+    <string name="unhide_app">Unhide</string>
     <string name="app_gone">This App is gone :-(</string>
     <string name="show_no_icons_pure_text">Only show app names, not the icons</string>
+    <string name="show_even_hidden">Show hidden apps</string>
+    <string name="show_even_hidden_summary">Sorted to end of list</string>
     <string name="max_text_lines">Lines of text</string>
     <string name="how_much_text_you_want">Max number of lines used to display app name</string>
     <string name="create_shortcut">Create shortcut</string>
@@ -39,6 +43,8 @@
     <string name="remove_cache_descr">Force FAST to reset app list and history</string>
     <string name="icon_resolution_title">Icon Resolution</string>
     <string name="icon_resolution_summary">More speed or more pixels?</string>
+    <string name="pin_app">Pin</string>
+    <string name="unpin_app">Unpin</string>
     <string-array name="sizes">
         <item>Tiny</item>
         <item>Small</item>

--- a/android/src/test/java/org/ligi/fast/testing/MutableFastSettings.java
+++ b/android/src/test/java/org/ligi/fast/testing/MutableFastSettings.java
@@ -83,5 +83,8 @@ public class MutableFastSettings implements FASTSettings {
         return Integer.parseInt(AndroidFASTSettings.DEFUAULT_ICON_RESOLUTION);
     }
 
-
+    @Override
+    public boolean isShowHiddenActivated() {
+        return false;
+    }
 }

--- a/promo/txt/play.txt
+++ b/promo/txt/play.txt
@@ -2,10 +2,13 @@
     <string name="long">Find and Launch Applications fast and for free with a small App that needs not a single permission!
 Just type in a fraction of the name of the App you want to launch - most of the time 3 chars are enough.
 
-A single click launches the App - a long click gives you 3 Options:
- #1 Go to the App details
- #2 Open the App in Google Play
- #3 Open the App as a Notification for FAST access at a later time
+A single click launches the App - a long click gives you 6 Options:
+ 1. Go to the App details
+ 2. Customize its Label or create additional entries for the App
+ 3. Pin the App to top
+ 4. Hide the App
+ 5. Open the App as a Notification for FAST access at a later time
+ 6. Open the App in Google Play
 
 The App is GPLv3 - you can find the source on GitHub: https://github.com/ligi/FAST
 


### PR DESCRIPTION
**Add CATEGORY_LAUNCHER to intent when starting an app:**
Without adding this category in some cases the referenced activity might be recreated and placed on top of the current back stack. Therefore the user needs to press the back button to get to the last used activity.
After adding this category the last used activity is brought to front automatically.

**Fix Merge Conflicts for ShadowKyogre's Hide Implementation**
I really like hiding apps on my launcher.
This should close #59, #62 and #86 

**Aliasing and Renaming**
Closes #50 

**Fix #35**