### PR TITLE
AppActionDialog: Add flags to make App Details appear in recents

### DIFF
--- a/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
+++ b/android/src/main/java/org/ligi/fast/ui/AppActionDialogBuilder.java
@@ -195,10 +195,14 @@ public class AppActionDialogBuilder extends AlertDialog.Builder {
                                                 String packageName) {
         Intent intent = new Intent();
         final int apiLevel = Build.VERSION.SDK_INT;
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         if (apiLevel >= 9) { // above 2.3
             intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
             Uri uri = Uri.fromParts(SCHEME, packageName, null);
             intent.setData(uri);
+            if (apiLevel >= 11) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+            }
         } else { // below 2.3
             final String appPkgName = (apiLevel == 8 ? APP_PKG_NAME_22 : APP_PKG_NAME_21);
             intent.setAction(Intent.ACTION_VIEW);


### PR DESCRIPTION
I've missed this behavior from Trebuchet.

On Gingerbread and above this additionally keeps a separate instances for every app detail page opened.